### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/tsub",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Tsub for JS",
   "main": "dist/index.js",
   "browser": "dist/index.js",


### PR DESCRIPTION
I used `yarn publish` to publish `v0.1.8` and it only included `dist/index.js` in its tarball excluding all other files in `/dist` (can't explain why yet).

In the meantime, I'm bumping the version to republish since NPM won't unpublish `v0.1.8`. The dry-run:
```
tsub-js on  0.1.9 [?⇡] is 📦 v0.1.9 via  v14.17.1 on ☁️  (us-west-2)
✦3 ❯ npm publish --dry-run
npm notice
npm notice 📦  @segment/tsub@0.1.9
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 637B   dist/index.js
npm notice 238B   jest.config.js
npm notice 14.0kB dist/matchers.js
npm notice 765B   dist/store.js
npm notice 9.1kB  dist/transformers.js
npm notice 577B   dist/unset.js
npm notice 25.8kB fixtures/evilStrings.json
npm notice 20.4kB fixtures/manyProperties.json
npm notice 1.5kB  package.json
npm notice 1.0kB  fixtures/simple.json
npm notice 455B   tsconfig.json
npm notice 1.7kB  tslint.json
npm notice 208B   dist/index.js.map
npm notice 11.0kB dist/matchers.js.map
npm notice 553B   dist/store.js.map
npm notice 6.1kB  dist/transformers.js.map
npm notice 712B   dist/unset.js.map
npm notice 292B   README.md
npm notice 42.1kB segment-tsub-0.1.7.tgz
npm notice 31.1kB segment-tsub-0.1.8.tgz
npm notice 148B   dist/index.d.ts
npm notice 2.9kB  src/__tests__/index.test.ts
npm notice 145B   src/index.ts
npm notice 112B   dist/matchers.d.ts
npm notice 9.4kB  src/__tests__/matchers.test.ts
npm notice 12.0kB src/matchers.ts
npm notice 514B   dist/store.d.ts
npm notice 834B   src/store.ts
npm notice 526B   dist/transformers.d.ts
npm notice 12.2kB src/__tests__/transformers.test.ts
npm notice 8.6kB  src/transformers.ts
npm notice 61B    dist/unset.d.ts
npm notice 375B   src/unset.ts
npm notice 1.1kB  .github/workflows/ci.yml
npm notice === Tarball Details ===
npm notice name:          @segment/tsub
npm notice version:       0.1.9
npm notice package size:  118.3 kB
npm notice unpacked size: 218.2 kB
npm notice shasum:        15690b62b3cd01ddd7ef53db8012a8941770b22b
npm notice integrity:     sha512-m2ZTotDbXx0iW[...]jZjtWFEwEIaeQ==
npm notice total files:   35
npm notice
+ @segment/tsub@0.1.9
```