### PR TITLE
set dset dependency ^3.1.1 for improving security

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@stdlib/math-base-special-ldexp": "^0.0.5",
     "dlv": "^1.1.3",
-    "dset": "3.1.1",
+    "dset": "^3.1.1",
     "tiny-hashes": "^1.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,10 +1988,10 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
-dset@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.1.tgz#07de5af7a8d03eab337ad1a8ba77fe17bba61a8c"
-  integrity sha512-hYf+jZNNqJBD2GiMYb+5mqOIX4R4RRHXU3qWMWYN+rqcR2/YpRL2bUHr8C8fU+5DNvqYjJ8YvMGSLuVPWU1cNg==
+dset@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.2.tgz#89c436ca6450398396dc6538ea00abc0c54cd45a"
+  integrity sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==
 
 electron-to-chromium@^1.4.17:
   version "1.4.53"


### PR DESCRIPTION
Change `dset` dependency from `3.1.1` to `^3.1.1` 